### PR TITLE
BUGFIX: Handle checked root-node

### DIFF
--- a/Classes/Service/DynamicRoleEditorService.php
+++ b/Classes/Service/DynamicRoleEditorService.php
@@ -156,7 +156,7 @@ class DynamicRoleEditorService
 
         foreach ($dynamicRoleMatcherConfiguration->getSelectedNodeIdentifiers() as $nodeIdentifier) {
             $node = $this->getSiteNode()->getContext()->getNodeByIdentifier($nodeIdentifier);
-            if ($node && $node->getParent()) {
+            if ($node && $node->getParent() && $node !== $siteNode) {
                 // the node itself does not need to be expanded, but all parents should be expanded (so that the node which has the restriction is visible in the tree)
                 while ($node->getParent() !== $siteNode) {
                     $node = $node->getParent();


### PR DESCRIPTION
Fixes #11

**What I did**
When the checked node is the root-node (siteNode), no expading of parent nodes is needed, so I added $node !== $siteNode to the already existing if-condition.

**How to verify it**
Try the steps in #11. The exception will not happen anymore.