### PR TITLE
BUGFIX: fix check for allowed workspaces

### DIFF
--- a/Classes/Domain/Dto/MatcherConfiguration.php
+++ b/Classes/Domain/Dto/MatcherConfiguration.php
@@ -63,7 +63,7 @@ class MatcherConfiguration
         }
 
         $selectedDimensionPresets = [];
-        foreach ($json['selectedDimensionPresets']as $config) {
+        foreach ($json['selectedDimensionPresets'] as $config) {
             $selectedDimensionPresets[] = MatcherConfigurationSelectedDimensionPreset::fromConfig($config);
         }
 
@@ -88,15 +88,21 @@ class MatcherConfiguration
 
     private static function generatePolicyMatcherStringForSelectedWorkspaces(array $selectedWorkspaces): string
     {
-        $matcherParts = [];
-        foreach ($selectedWorkspaces as $workspace) {
-            $matcherParts[] = sprintf('isInWorkspace("%s")', $workspace);
-        }
-        if (empty($matcherParts)) {
+        if (empty($selectedWorkspaces)) {
             return 'true';
         }
 
-        return '(' . implode(' || ', $matcherParts) . ')';
+        /**
+         * isInWorkspace(["live", "workspace"]) will check if any of the given workspaces matches.
+         * The "live" workspace is always required, otherwise you will never be able to edit existing content already published to live.
+         * To restrict editing the "live" workspace, simply remove "LivePublisher" from parent roles.
+         */
+        $matcherPart = sprintf(
+            'isInWorkspace(["%s", "live"])',
+            implode('", "', $selectedWorkspaces)
+        );
+
+        return $matcherPart;
     }
 
     private static function generatePolicyMatcherStringForSelectedDimensions(array $dimensionPresets)

--- a/Classes/Service/DynamicRoleEditorService.php
+++ b/Classes/Service/DynamicRoleEditorService.php
@@ -119,7 +119,7 @@ class DynamicRoleEditorService
         foreach ($this->workspaceRepository->findAll() as $workspace) {
             /* @var $workspace \Neos\ContentRepository\Domain\Model\Workspace */
 
-            if (!$workspace->isPersonalWorkspace()) {
+            if (!$workspace->isPersonalWorkspace() && $workspace->getName() !== 'live') {
                 $result[] = [
                     'name' => $workspace->getName(),
                     'label' => $workspace->getTitle()


### PR DESCRIPTION
### What I did

Previously the check for workspaces was done by adding `( isInWorkspace("workspaceA") || isInWorkspace("workspaceB") )` to the generated policy. But `isInWorkspace()` requires an array of all valid workspaces. 

I fixed the issue by generating `isInWorkspace(["workspaceA", "workspaceB"])` for the policy. I also always added the "live" workspace to this check as otherwise users with this role won't be able to change anything that is published to live even if they are in one of the restricted workspaces. To restrict a user from publishing to live, simply don't add the (parent) role "LivePublisher".

### How to verify it

- Login
- Create new role
- Select workspaces you want to restrict the role to (create a new one if you do not have any except live yet)
- Create a new test user and apply the new role to it
- See if you can publish to any workspace not selected previously

Checklist

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed --> I only tested the change manually

This also fixes #34 