### PR TITLE
TASK: Order list of roles by name

### DIFF
--- a/Classes/Domain/Repository/DynamicRoleRepository.php
+++ b/Classes/Domain/Repository/DynamicRoleRepository.php
@@ -1,5 +1,6 @@
 <?php
 namespace Sandstorm\NeosAcl\Domain\Repository;
+use Neos\Flow\Persistence\QueryInterface;
 
 /*
  * This file is part of the Neos.ACLInspector package.
@@ -13,4 +14,5 @@ use Neos\Flow\Persistence\Doctrine\Repository;
  */
 class DynamicRoleRepository extends Repository
 {
+    protected $defaultOrderings = ['name' => QueryInterface::ORDER_ASCENDING];
 }


### PR DESCRIPTION
The list of all roles in the backend module has no default orderings, therefore it is randomly sorted. Sorting by name makes more sense.