### PR TITLE
BUGFIX: When editing role, filter current role from parent role selector

### DIFF
--- a/Classes/Controller/Module/DynamicRoleController.php
+++ b/Classes/Controller/Module/DynamicRoleController.php
@@ -135,8 +135,20 @@ class DynamicRoleController extends ActionController
 
     protected function assignAvailableRoles(DynamicRole $roleToEdit = null)
     {
+        $hiddenRoles = [
+            'Neos.Neos:Editor',
+            'Neos.Neos:Administrator',
+            'Neos.Neos:SetupUser',
+        ];
+
+        if ($roleToEdit) {
+            $hiddenRoles[] = 'Dynamic:' . $roleToEdit->getName();
+        }
+
         $this->view->assign('availableRoles', array_filter($this->policyService->getRoles(), function(Role $role) use ($roleToEdit) {
-            return $role->getIdentifier() !== 'Neos.Neos:Editor' && $role->getIdentifier() !== 'Neos.Neos:Administrator' && $role->getIdentifier() !== 'Neos.Neos:SetupUser' && (!$roleToEdit || $role->getIdentifier() !== 'Dynamic:' . $roleToEdit->getName());
+            if (in_array($role->getIdentifier(), $hiddenRoles, true)) {
+                return false;
+            }
         }));
     }
 }


### PR DESCRIPTION
It should not be possible to select the current role as parent role when editing a role. This could lead to loops.

Fixes: https://github.com/sandstorm/NeosAcl/issues/36