### PR TITLE
array_filter must return true if role should be kept in array

### DIFF
--- a/Classes/Controller/Module/DynamicRoleController.php
+++ b/Classes/Controller/Module/DynamicRoleController.php
@@ -149,6 +149,7 @@ class DynamicRoleController extends ActionController
             if (in_array($role->getIdentifier(), $hiddenRoles, true)) {
                 return false;
             }
+            return true;
         }));
     }
 }


### PR DESCRIPTION
List of parent roles are empty on create dynamic role. Cause assignAvailableRoles returns empty array.

closes #46 